### PR TITLE
存在しないユーザーIDによるTweetを許可しない

### DIFF
--- a/src/main/java/com/example/tweet/controllers/TopController.java
+++ b/src/main/java/com/example/tweet/controllers/TopController.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.tweet.entities.Tweet;
 import com.example.tweet.services.TweetService;
+import com.example.tweet.services.UserService;
 import com.example.tweet.common.errors.NoExistRecordError;
 import com.example.tweet.common.validation.TweetValidator;
 
@@ -24,6 +25,8 @@ import jakarta.xml.bind.ValidationException;
 public class TopController {
     @Autowired
     private TweetService tweetService;
+    @Autowired
+    private UserService userService;
 
     @RequestMapping("/")
     public ModelAndView topTweetPageString() {
@@ -110,5 +113,20 @@ public class TopController {
 
         redirectAttributes.addFlashAttribute("message", updatedMessage);
         return "redirect:/";
+    }
+
+    @GetMapping("/createUser")
+    public ModelAndView createUserProcess(HttpServletRequest request) {
+        String userName = (request.getParameter("name"));
+        String userPassword = (request.getParameter("password"));
+        ModelAndView model = new ModelAndView("/createUser.html");
+        try {
+            userService.createUser(userName, userPassword);
+            model.addObject("message", "ユーザーが追加されました。");
+        } catch (Exception e) {
+            model.addObject("message", "ユーザー登録に失敗しました。");
+        }
+
+        return model;
     }
 }

--- a/src/main/java/com/example/tweet/controllers/TopController.java
+++ b/src/main/java/com/example/tweet/controllers/TopController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -62,6 +63,9 @@ public class TopController {
 
         } catch (ValidationException ex) {
             redirectAttributes.addFlashAttribute("validMessage", ex.getMessage());
+            System.out.println(ex.getMessage());
+        } catch (IncorrectResultSizeDataAccessException ex) {
+            redirectAttributes.addFlashAttribute("validMessage", "該当ユーザーが存在しません");
             System.out.println(ex.getMessage());
         } catch (DataAccessException ex) {
             redirectAttributes.addFlashAttribute("message", ex.getMessage());

--- a/src/main/java/com/example/tweet/controllers/TopController.java
+++ b/src/main/java/com/example/tweet/controllers/TopController.java
@@ -115,7 +115,7 @@ public class TopController {
         return "redirect:/";
     }
 
-    @GetMapping("/createUser")
+    @RequestMapping("/createUser")
     public ModelAndView createUserProcess(HttpServletRequest request) {
         String userName = (request.getParameter("name"));
         String userPassword = (request.getParameter("password"));

--- a/src/main/java/com/example/tweet/dao/UserDao.java
+++ b/src/main/java/com/example/tweet/dao/UserDao.java
@@ -8,6 +8,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import com.example.tweet.common.errors.NoExistRecordError;
 import com.example.tweet.entities.User;
 
 @Repository
@@ -17,7 +18,6 @@ public class UserDao {
 
     public User findUser(int userId) {
         try {
-
             String sql = "SELECT name FROM user WHERE id = ?;";
             RowMapper<User> user = new BeanPropertyRowMapper<User>(User.class);
             // 実行結果件数を取得
@@ -29,6 +29,21 @@ public class UserDao {
             throw ex;
         } catch (DataAccessException ex) {
             System.out.println("[findUser]occur error");
+            throw ex;
+        }
+    }
+
+    public void createUser(String name, String password) throws NoExistRecordError {
+        try {
+            String sql = "INSERT INTO tweet(name, password) VALUES(?, ?);";
+            // 実行結果件数を取得
+            int resultNum = cnn.update(sql, name, password);
+
+            if (resultNum == 0) {
+                throw new NoExistRecordError("No tweets to update");
+            }
+        } catch (DataAccessException ex) {
+            System.out.println("[createUser]occur error");
             throw ex;
         }
     }

--- a/src/main/java/com/example/tweet/dao/UserDao.java
+++ b/src/main/java/com/example/tweet/dao/UserDao.java
@@ -1,0 +1,35 @@
+package com.example.tweet.dao;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+import com.example.tweet.entities.User;
+
+@Repository
+public class UserDao {
+    @Autowired
+    private JdbcTemplate cnn;
+
+    public User findUser(int userId) {
+        try {
+
+            String sql = "SELECT name FROM user WHERE id = ?;";
+            RowMapper<User> user = new BeanPropertyRowMapper<User>(User.class);
+            // 実行結果件数を取得
+            User oneUser = cnn.queryForObject(sql, user, userId);
+            return oneUser;
+
+        } catch (IncorrectResultSizeDataAccessException ex) {
+            System.out.println("[findUser]not found user");
+            throw ex;
+        } catch (DataAccessException ex) {
+            System.out.println("[findUser]occur error");
+            throw ex;
+        }
+    }
+}

--- a/src/main/java/com/example/tweet/entities/User.java
+++ b/src/main/java/com/example/tweet/entities/User.java
@@ -25,7 +25,7 @@ public class User {
         return password;
     }
 
-    public void setPassword(String Password) {
-        this.password = Password;
+    public void setPassword(String password) {
+        this.password = password;
     }
 }

--- a/src/main/java/com/example/tweet/entities/User.java
+++ b/src/main/java/com/example/tweet/entities/User.java
@@ -1,0 +1,31 @@
+package com.example.tweet.entities;
+
+public class User {
+    private int id;
+    private String name;
+    private String password;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String Password) {
+        this.password = Password;
+    }
+}

--- a/src/main/java/com/example/tweet/services/TweetService.java
+++ b/src/main/java/com/example/tweet/services/TweetService.java
@@ -7,12 +7,16 @@ import org.springframework.stereotype.Service;
 
 import com.example.tweet.common.errors.NoExistRecordError;
 import com.example.tweet.dao.TweetDao;
+import com.example.tweet.dao.UserDao;
 import com.example.tweet.entities.Tweet;
 
 @Service
 public class TweetService {
     @Autowired
     private TweetDao tweetDao;
+
+    @Autowired
+    private UserDao userDao;
 
     // 動作確認としてDaoメソッドの戻り値を返すだけ
     public List<Tweet> fetchTweetList() {
@@ -22,6 +26,7 @@ public class TweetService {
 
     // つぶやく新規追加時のSQL実行結果件数を返す
     public int insertTweet(int userId, String tweetContent) throws NoExistRecordError {
+        userDao.findUser(userId);
         int resultNum = tweetDao.insertOneTweet(userId, tweetContent);
         return resultNum;
     }

--- a/src/main/java/com/example/tweet/services/UserService.java
+++ b/src/main/java/com/example/tweet/services/UserService.java
@@ -1,0 +1,19 @@
+package com.example.tweet.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.tweet.common.errors.NoExistRecordError;
+import com.example.tweet.dao.UserDao;
+
+@Service
+public class UserService {
+    @Autowired
+    private UserDao userDao;
+
+    // つぶやく新規追加時のSQL実行結果件数を返す
+    public void createUser(String name, String password) throws NoExistRecordError {
+        userDao.createUser(name, password);
+    }
+
+}

--- a/src/main/resources/static/css/top.css
+++ b/src/main/resources/static/css/top.css
@@ -9,11 +9,12 @@ body {
 label {
   display: block;
 }
+
 input {
   display: block;
 }
 
-.button {
+.formBtn {
   margin-top: 10px;
 }
 

--- a/src/main/resources/templates/createUser.html
+++ b/src/main/resources/templates/createUser.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+    <meta charset="UTF-8">
+    <link th:href="@{./css/top.css}" rel="stylesheet">
+</head>
+
+<body>
+    <div id="container">
+        <h2>新規投稿</h2>
+        <th:block th:if="!${#strings.isEmpty(validMessage)}">
+            <h3 th:text="${validMessage}"></h3>
+        </th:block>
+        <form method="POST" action="/createUser">
+            <label>user id</label>
+            <input type="text" name="user_id" placeholder="1">
+            <label>name</label>
+            <input type="text" name="name" placeholder="name">
+            <label>password</label>
+            <input type="password" name="password" placeholder="password">
+            <input class="formBtn" type="submit" value="追加する">
+        </form>
+        <a href="/">TOPへ戻る</a>
+    </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/createUser.html
+++ b/src/main/resources/templates/createUser.html
@@ -8,7 +8,7 @@
 
 <body>
     <div id="container">
-        <h2>新規投稿</h2>
+        <h2>ユーザー作成</h2>
         <th:block th:if="!${#strings.isEmpty(validMessage)}">
             <h3 th:text="${validMessage}"></h3>
         </th:block>

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -17,7 +17,7 @@
             <input type="text" name="user_id" placeholder="1"><br>
             <label>content</label>
             <input type="text" name="content" placeholder="content">
-            <input type="submit" value="投稿する">
+            <input class="formBtn" type="submit" value="投稿する">
         </form>
         <h2>参照</h2>
         <th:block th:if="${#lists.isEmpty(tweetList)}">
@@ -47,7 +47,7 @@
                 </tr>
             </table>
         </th:block>
-        <a href="/">TOPへ戻る</a>
+        <a href="/createUser">ユーザーを作成する</a>
     </div>
 </body>
 


### PR DESCRIPTION
## やったこと

- 新規登録時に入力するuser_idがuserテーブルに存在しない場合には登録しない処理を追加しました。
- ユーザー登録画面を追加しました。
  - userテーブルに意味を持たせるため


## やってないこと

- 一覧表示時にuser_idをuser nameに変換する処理
- ログイン認証周りはSpring Securityが必要になり、趣旨に反すると考えたため。
- ユーザー登録時のパスワードは平文で登録するなど、セキュリティについては一切考慮していません。

## 確認してほしいこと

- 新人教育の趣旨から外れていないか？
- ログイン機構がない状態でユーザー周りの処理が必要かどうか
- Javaとしてのコーディング規約に反していないかどうか？

## スクリーンショット

- ユーザー登録画面
![image](https://github.com/i-v-FSD/springTraining/assets/50798130/02fc4a6f-e340-4808-99c0-d506102cabc0)

- ユーザー存在エラー時
![image](https://github.com/i-v-FSD/springTraining/assets/50798130/1c760f2f-b4c3-442c-9534-c708a640b428)
