### PR TITLE
ValidationErrorが利用できない可能性がある不具合への対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'


### PR DESCRIPTION
## やったこと

- 環境によって、バリデーションで利用しているパッケージが動かない可能性があったため、依存関係にパッケージを指定しました
- すべてのJava環境で必要ではないと思われるため、エラーになった人は取り込んでください
- 参考：https://www.w3docs.com/snippets/java/java-11-package-javax-xml-bind-does-not-exist.html
