### PR TITLE
【sample】entityの定義をSpringの機能に寄せる

### DIFF
--- a/src/main/java/com/example/tweet/entities/BaseEntity.java
+++ b/src/main/java/com/example/tweet/entities/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.tweet.entities;
+
+import java.util.Date;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Data;
+
+@Data
+@MappedSuperclass
+/**
+ * 各テーブルで共通するフィールドを定義する
+ */
+public class BaseEntity {
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created_at")
+    private Date created;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "updated_at")
+    private Date updated;
+}

--- a/src/main/java/com/example/tweet/entities/Tweet.java
+++ b/src/main/java/com/example/tweet/entities/Tweet.java
@@ -1,31 +1,30 @@
 package com.example.tweet.entities;
 
-public class Tweet {
-    private int id;
-    private int userId;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * Tweetテーブル独自フィールドを定義する
+ */
+@EqualsAndHashCode(callSuper = false)
+@Data
+@Entity
+@Table(name = "tweet")
+public class Tweet extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "user_id")
+    private Integer userId;
+
+    @Column(name = "content")
     private String content;
-
-    public int getId() {
-        return id;
-    }
-
-    public void setId(int id) {
-        this.id = id;
-    }
-
-    public int getUserId() {
-        return userId;
-    }
-
-    public void setUserId(int userId) {
-        this.userId = userId;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
-    }
 }


### PR DESCRIPTION
## やったこと

- Entityの定義をJPAに寄せています
  - `mybatis`までは使わない方針だったと思うので、このあたりが落としどころかなと。
  - Dao層は引き続きjdbcTemplateを使い、研修生にはSQLを書く練習をしてもらうはず
- 通しで動くことまでは確認しています
- あくまでサンプルなので、実装するならCRUD全体で認識合わせてください
  - User Entityの作りも合わせる必要があると思います

## やってないこと

- Dao層など他の部分は実装していません
- 担当外タスクのため、Draftで止めています
 
## その他

- 参考：[JPAという便利なものがあるらしい](https://qiita.com/takaakitanaka_cre-co/items/fd1496ad39560c2cb9d4)

